### PR TITLE
Handle 401 response to refresh session

### DIFF
--- a/api/configlet.go
+++ b/api/configlet.go
@@ -268,15 +268,15 @@ func (c CvpRestAPI) updateConfiglet(config string, name string, key string,
 
 	resp, err := c.client.Post("/configlet/updateConfiglet.do", nil, data)
 	if err != nil {
-		return nil, errors.Errorf("updateConfiglet: %s", err)
+		return nil, err
 	}
 
 	if err = json.Unmarshal(resp, &info); err != nil {
-		return nil, errors.Errorf("updateConfiglet: %s", err)
+		return nil, err
 	}
 
 	if err := info.Error(); err != nil {
-		return nil, errors.Errorf("updateConfiglet: %s", err)
+		return nil, err
 	}
 
 	return &info, nil

--- a/client/client.go
+++ b/client/client.go
@@ -300,12 +300,12 @@ func (c *CvpClient) makeRequest(reqType string, url string, params *url.Values,
 	data interface{}) ([]byte, error) {
 	var err error
 	var resp *resty.Response
-	var formatedParams map[string]string
+	var formattedParams map[string]string
 
 	retryCnt := NumRetryRequests
 
 	if params != nil {
-		formatedParams, err = parseURLValues(params)
+		formattedParams, err = parseURLValues(params)
 		if err != nil {
 			return nil, err
 		}
@@ -315,7 +315,7 @@ func (c *CvpClient) makeRequest(reqType string, url string, params *url.Values,
 	for nodeCnt > 0 {
 
 		request := c.Client.R()
-		request.SetQueryParams(formatedParams)
+		request.SetQueryParams(formattedParams)
 
 		// If we've seen an error
 		if err != nil {


### PR DESCRIPTION
Addresses issue #29

* Fixed issue related to headers growing after retry
* Refresh session on 401 response