### PR TITLE
Check Compliance returns empty string for CVP2018.2

### DIFF
--- a/api/cvprac_system_test.go
+++ b/api/cvprac_system_test.go
@@ -360,8 +360,9 @@ func TestCvpRac_CheckCompliance_SystemTest(t *testing.T) {
 	ok(t, err)
 	assert(t, res.ComplianceCode == "0000", "Expected: \"0000\", Got: \"%s\"",
 		res.ComplianceCode)
-	assert(t, res.ComplianceIndication == "NONE", "Expected: \"NONE\", Got: \"%s\"",
+	assert(t, res.ComplianceIndication == "", "Expected: \"\", Got: \"%s\"",
 		res.ComplianceIndication)
+
 }
 
 func TestCvpRac_GetParentContainerForDevice_SystemTest(t *testing.T) {


### PR DESCRIPTION
Addresses issue #34

Updated test to check for empty string on compliance check pass.