### PR TITLE
Issue 63

### DIFF
--- a/api/configlet.go
+++ b/api/configlet.go
@@ -439,7 +439,7 @@ func (c CvpRestAPI) SearchConfiglets(searchStr string) (*ConfigletList, error) {
 
 // GetAppliedDevices Returns a list of devices to which the named configlet is applied
 func (c CvpRestAPI) GetAppliedDevices(configletName string) ([]ObjectInfo, error) {
-	return c.client.GetAppliedDevicesWithRange(configletName, 0, 0)
+	return c.GetAppliedDevicesWithRange(configletName, 0, 0)
 }
 
 // GetAppliedDevicesWithRange Returns a list of devices to which the named configlet is applied

--- a/api/provisioning.go
+++ b/api/provisioning.go
@@ -282,29 +282,6 @@ func (vcc *ValidateAndCompareConfigletsResp) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Check data for ReconciledConfig
-	// This check is necessary because the ReconciledConfig is returned as an object when
-	// there is data but as an empty string when there is none
-	var newRecConf ReconciledConfig
-	json.Unmarshal(*objMap["reconciledConfig"], &newRecConf)
-	vcc.ReconciledConfig = newRecConf
-	// Check data for DesignedConfig
-	var newDesignedConfig []ConfigBlock
-	json.Unmarshal(*objMap["designedConfig"], &newDesignedConfig)
-	vcc.DesignedConfig = newDesignedConfig
-	// Check data for RunningConfig
-	var newRunningConfig []ConfigBlock
-	json.Unmarshal(*objMap["runningConfig"], &newRunningConfig)
-	vcc.RunningConfig = newRunningConfig
-	// Check data for Warnings
-	var newWarnings []string
-	json.Unmarshal(*objMap["warnings"], &newWarnings)
-	vcc.Warnings = newWarnings
-	// Check data for Total
-	var newTotal int
-	json.Unmarshal(*objMap["total"], &newTotal)
-	vcc.Total = newTotal
-
 	// Check data for Errors as list of strings. Return if found.
 	var newErrors []ValidateError
 	if err = json.Unmarshal(*objMap["errors"], &newErrors); err != nil {
@@ -320,14 +297,16 @@ func (vcc *ValidateAndCompareConfigletsResp) UnmarshalJSON(data []byte) error {
 		}
 	}
 	if len(newErrors) > 0 {
-		//vcc.Errors = newErrors
-		vcc.Errors = append(newErrors, ValidateError{ConfigletLineNo: 1, ErrorMsg: "Test"})
+		vcc.Errors = newErrors
 		return nil
 	}
 
-	// We do these last since they don't seem to be included in the return if the
-	// device has an error.
-
+	// Check data for ReconciledConfig
+	// This check is necessary because the ReconciledConfig is returned as an object when
+	// there is data but as an empty string when there is none
+	var newRecConf ReconciledConfig
+	json.Unmarshal(*objMap["reconciledConfig"], &newRecConf)
+	vcc.ReconciledConfig = newRecConf
 	// Check data for Reconcile
 	var newReconcile int
 	json.Unmarshal(*objMap["reconcile"], &newReconcile)
@@ -340,10 +319,26 @@ func (vcc *ValidateAndCompareConfigletsResp) UnmarshalJSON(data []byte) error {
 	var newMismatch int
 	json.Unmarshal(*objMap["mismatch"], &newMismatch)
 	vcc.Mismatch = newMismatch
+	// Check data for Total
+	var newTotal int
+	json.Unmarshal(*objMap["total"], &newTotal)
+	vcc.Total = newTotal
 	// Check data for IsReconcileInvoked
 	var newInvoked bool
 	json.Unmarshal(*objMap["isReconcileInvoked"], &newInvoked)
 	vcc.IsReconcileInvoked = newInvoked
+	// Check data for DesignedConfig
+	var newDesignedConfig []ConfigBlock
+	json.Unmarshal(*objMap["designedConfig"], &newDesignedConfig)
+	vcc.DesignedConfig = newDesignedConfig
+	// Check data for RunningConfig
+	var newRunningConfig []ConfigBlock
+	json.Unmarshal(*objMap["runningConfig"], &newRunningConfig)
+	vcc.RunningConfig = newRunningConfig
+	// Check data for Warnings
+	var newWarnings []string
+	json.Unmarshal(*objMap["warnings"], &newWarnings)
+	vcc.Warnings = newWarnings
 	return nil
 }
 


### PR DESCRIPTION
Update and handle response from v2/validateAndCompareConfiglets.do

Test
```console
----------------------------------------------------------
RESTY 2020/07/02 18:37:18
---------------------- REQUEST LOG -----------------------
POST  /web/provisioning/v2/validateAndCompareConfiglets.do  HTTP/1.1
HOST   : 10.16.129.225:443
HEADERS:
                   Accept: application/json
             Content-Type: application/json
                   Cookie: session_id=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1OTM4MTU4MzgsImdlbmVyYXRlZEF0IjoxNTkzNzI5NDM4MjExMTIyMDY1LCJpYXQiOjE1OTM3Mjk0MzgsImlzcyI6ImFhYSIsImp0aSI6ImN2cGFkbWluIiwibmJmIjoxNTkzNzI5NDM4LCJzdWIiOiJDdnAgYXV0aGVudGljYXRpb24ifQ.V9vcZ9BIu04kIQWvtUeIpM23Q2jZCobv2JRQ6s9w6Uk
               User-Agent: Golang cvprac/v2.4.1
BODY   :
{
   "netElementId": "04:d0:47:66:a9:9c",
   "configIdList": [
      "configlet_122_2562893438626"
   ],
   "pageType": "validateConfig"
}
----------------------------------------------------------
RESTY 2020/07/02 18:37:19
---------------------- RESPONSE LOG -----------------------
STATUS 		: 200
RECEIVED AT	: 2020-07-02T18:37:19.832283-04:00
RESPONSE TIME	: 1.538506082s
HEADERS:
               Connection: keep-alive
      Content-Disposition: inline;filename=f.txt
           Content-Length: 3943
  Content-Security-Policy: frame-ancestors 'none';
             Content-Type: application/json;charset=ISO-8859-1
                     Date: Thu, 02 Jul 2020 22:37:19 GMT
               Set-Cookie: JSESSIONID=04C76C897216770F4DCDD2103D3379B5; Path=/cvpservice; Secure; HttpOnly, redirectURL=; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure, redirectURL=; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/web/; Secure, redirectURL=; Max-Age=0; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; SameSite=lax; Secure
          X-Frame-Options: DENY
BODY   :
{
   "reconciledConfig": "",
   "designedConfig": "",
   "total": "",
   "runningConfig": "! Command: show running-config\n! device: leaf1A (vEOS, EOS-4.21.2F)\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -ingestgrpcurl=192.168.0.5:9910 -taillogs -ingestauth=key,1a38fe7df56879d685e51b6f0ff86327 -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent\n   no shutdown\n!\ntransceiver qsfp default-mode 4x10G\n!\nagent PhyEthtool shutdown\n!\nhostname leaf1A\n!\nspanning-tree mode mstp\n!\naaa authorization exec default local\n!\nno aaa root\n!\nusername admin privilege 15 role network-admin secret sha512 $6$5O0Yp.IL9fViuvSQ$bZ7yPw3DDVYXVMlB5hiBwD41V./plWrW78VWQ1uACi37KALhGjosxddqYGxii39U6mGi6TQ4/9USJxPnyoPmp.\nusername arista privilege 15 role network-admin secret sha512 $6$4OG7xmOsMGgJLqWj$og1/f1963A8K40jHbJ6wclqXHJF3H40kP9W.yK/XBiAGMY3zflR9AWMZ2iv9rWQVkHRRaMG/JsYFWsr4MCALu/\nusername cvpadmin privilege 15 role network-admin secret 5 $1$1CA$lhDGhns8LMAuuaYwnTdpV.\n!\nvlan 10-15\n   name SERVER\n!\nvlan 4094\n   name MLAG-PEER-VLAN\n   trunk group MLAG-PEER\n!\ninterface Port-Channel2000\n   description MLAG Connection\n   switchport mode trunk\n   switchport trunk group MLAG-PEER\n!\ninterface Ethernet1\n   description Connection to spine1-Ethernet1\n   no switchport\n   ip address 10.153.200.1/31\n!\ninterface Ethernet2\n   description Connection to spine2-Ethernet1\n   no switchport\n   ip address 10.153.200.5/31\n!\ninterface Ethernet3\n   description MLAG-PEER-LINK to leaf1B-Ethernet3\n   channel-group 2000 mode active\n!\ninterface Ethernet4\n   description MLAG-PEER-LINK to leaf1B-Ethernet4\n   channel-group 2000 mode active\n!\ninterface Ethernet5\n!\ninterface Ethernet6\n!\ninterface Ethernet7\n!\ninterface Ethernet8\n!\ninterface Ethernet9\n!\ninterface Ethernet10\n!\ninterface Ethernet11\n!\ninterface Ethernet12\n!\ninterface Ethernet13\n!\ninterface Ethernet14\n!\ninterface Ethernet15\n!\ninterface Ethernet16\n!\ninterface Ethernet17\n!\ninterface Ethernet18\n!\ninterface Ethernet19\n!\ninterface Ethernet20\n!\ninterface Ethernet21\n!\ninterface Ethernet22\n!\ninterface Ethernet23\n!\ninterface Ethernet24\n!\ninterface Ethernet25\n!\ninterface Ethernet26\n!\ninterface Ethernet27\n!\ninterface Ethernet28\n!\ninterface Ethernet29\n!\ninterface Ethernet30\n!\ninterface Ethernet31\n!\ninterface Ethernet32\n!\ninterface Loopback0\n   description BGP router-Id\n   ip address 10.153.199.3/32\n!\ninterface Management1\n   ip address 192.168.0.7/24\n!\ninterface Vlan4094\n   description MLAG to leaf1B\n   ip address 10.153.200.8/31\n!\nip virtual-router mac-address 00:1c:73:00:00:99\n!\nip route 0.0.0.0/0 192.168.0.1\n!\nip routing\n!\nip prefix-list loopback\n   seq 10 permit 10.153.199.3/32\n!\nmlag configuration\n   domain-id MLAG\n   local-interface Vlan4094\n   peer-address 10.153.200.9\n   peer-link Port-Channel2000\n!\nroute-map loopback permit 10\n   match ip address prefix-list loopback\n!\nrouter bgp 65002\n   bgp asn notation asdot\n   router-id 10.153.199.3\n   maximum-paths 32 ecmp 32\n   neighbor Peer_Leaf peer-group\n   neighbor Peer_Leaf remote-as 65002\n   neighbor Peer_Leaf next-hop-self\n   neighbor Peer_Leaf send-community extended\n   neighbor Peer_Leaf maximum-routes 12000 \n   neighbor Spine peer-group\n   neighbor Spine remote-as 65001\n   neighbor Spine send-community\n   neighbor Spine maximum-routes 12000 \n   neighbor 10.153.200.0 peer-group Spine\n   neighbor 10.153.200.0 description spine1\n   neighbor 10.153.200.4 peer-group Spine\n   neighbor 10.153.200.4 description spine2\n   neighbor 10.153.200.9 peer-group Peer_Leaf\n   neighbor 10.153.200.9 description leaf1B\n   redistribute connected route-map loopback\n!\nmanagement api http-commands\n   no shutdown\n!\nend\n",
   "warnings": [],
   "errors": [
      {
         "configletLineNo": 6,
         "error": "> crap% Invalid input at line 6",
         "configletId": "configlet_122_2562893438626"
      }
   ]
}
----------------------------------------------------------
2020/07/02 18:37:19 Failed to Get Device: ValidateConfigletsForDevice: "Line:6 Msg:> crap% Invalid input at line 6"
```