### PR TITLE
feature(provision): Add SetConfigletsToDevice

### DIFF
--- a/api/provisioning.go
+++ b/api/provisioning.go
@@ -436,6 +436,104 @@ type configletAndBuilderKeyNames struct {
 	bNames []string
 }
 
+func (c *configletAndBuilderKeyNames) Equals(other *configletAndBuilderKeyNames) bool {
+	if len(c.keys) != len(other.keys) || len(c.bKeys) != len(other.bKeys) {
+		return false
+	}
+
+	for i, v := range c.keys {
+		if v != other.keys[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func changesNeeded(applied, configlets []Configlet) (
+	*configletAndBuilderKeyNames, *configletAndBuilderKeyNames, error,
+) {
+	// configlets to set
+	configletAndBuilders, err := splitToConfigletAndBuilder(configlets)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rmConfiglets := configletDifference(applied, configlets)
+
+	rmConfigletAndBuilders, err := splitToConfigletAndBuilder(rmConfiglets)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &configletAndBuilders, &rmConfigletAndBuilders, nil
+}
+
+// SetConfigletsToDevice Sets the configlets to the device,
+// and removes configlets from the device not referenced in `configlets`.
+func (c CvpRestAPI) SetConfigletsToDevice(appName string, dev *NetElement, commit bool,
+	configlets ...Configlet) (*TaskInfo, error) {
+	if dev == nil {
+		return nil, errors.Errorf("SetConfigletsToDevice: nil NetElement")
+	}
+
+	// configlets to be removed; applied minus not in configlets
+	currentConfiglets, err := c.GetConfigletsByDeviceID(dev.SystemMacAddress)
+	if err != nil {
+		return nil, errors.Errorf("ApplyConfigletsToDevice: %s", err)
+	}
+
+	newCAndB, rmCAndB, err := changesNeeded(currentConfiglets, configlets)
+	if err != nil {
+		return nil, err
+	}
+
+	info := appName + ": Configlet Assign: to Device " + dev.Fqdn
+	infoPreview := "<b>Configlet Assign:</b> to Device" + dev.Fqdn
+
+	data := struct {
+		Data []Action `json:"data,omitempty"`
+	}{Data: []Action{
+		{
+			ID:                              1,
+			Info:                            info,
+			InfoPreview:                     infoPreview,
+			Note:                            "",
+			Action:                          "associate",
+			NodeType:                        "configlet",
+			NodeID:                          "",
+			ConfigletBuilderList:            newCAndB.bKeys,
+			ConfigletBuilderNamesList:       newCAndB.bNames,
+			ConfigletList:                   newCAndB.keys,
+			ConfigletNamesList:              newCAndB.names,
+			IgnoreConfigletBuilderNamesList: rmCAndB.bNames,
+			IgnoreConfigletBuilderList:      rmCAndB.bKeys,
+			IgnoreConfigletNamesList:        rmCAndB.names,
+			IgnoreConfigletList:             rmCAndB.keys,
+			ToID:                            dev.SystemMacAddress,
+			ToIDType:                        "netelement",
+			FromID:                          "",
+			NodeIPAddress:                   dev.IPAddress,
+			NodeName:                        "",
+			NodeTargetIPAddress:             dev.IPAddress,
+			FromName:                        "",
+			ToName:                          dev.Fqdn,
+			ChildTasks:                      []string{},
+			ParentTask:                      "",
+		},
+	}}
+
+	if err := c.addTempAction(data); err != nil {
+		return nil, errors.Errorf("SetConfigletsToDevice: %s", err)
+	}
+
+	if commit {
+		return c.SaveTopology()
+	}
+
+	return nil, nil
+}
+
 // ApplyConfigletsToDevice apply the configlets to the device.
 func (c CvpRestAPI) ApplyConfigletsToDevice(appName string, dev *NetElement, commit bool,
 	newConfiglets ...Configlet) (*TaskInfo, error) {
@@ -642,7 +740,6 @@ func (c CvpRestAPI) RemoveConfigletsFromDevice(appName string, dev *NetElement, 
 	if !action {
 		return nil, nil
 	}
-
 
 	info := appName + ": Configlet Remove: from Device " + dev.Fqdn
 	infoPreview := "<b>Configlet Remove:</b> from Device" + dev.Fqdn
@@ -1691,12 +1788,12 @@ func (c CvpRestAPI) FilterTopology(nodeID, query string) (*Topology, error) {
 // elements not in c1, but are in c2 are appended to c1 and returned
 func configletUnion(c1, c2 []Configlet) []Configlet {
 	configletMap := make(map[string]string)
-	for _, configlet  := range c1 {
+	for _, configlet := range c1 {
 		configletMap[configlet.Key] = configlet.Name
 	}
 
 	for _, c := range c2 {
-		if _, found := configletMap[c.Key]; ! found {
+		if _, found := configletMap[c.Key]; !found {
 			c1 = append(c1, c)
 		}
 	}
@@ -1714,8 +1811,8 @@ func configletDifference(c1, c2 []Configlet) []Configlet {
 
 	var configletsToRemain []Configlet
 
-	for _, c := range c1  {
-		if _, found := rmKeys[c.Key]; ! found {
+	for _, c := range c1 {
+		if _, found := rmKeys[c.Key]; !found {
 			configletsToRemain = append(configletsToRemain, c)
 		}
 	}
@@ -1728,7 +1825,7 @@ func configletDifference(c1, c2 []Configlet) []Configlet {
 // and builderMap.
 func checkConfigMapping(applied []Configlet, newconfiglets []Configlet) (bool,
 	configletAndBuilderKeyNames, error,
-	) {
+) {
 	configlets := configletUnion(applied, newconfiglets)
 
 	configletAndBuilders, err := splitToConfigletAndBuilder(configlets)
@@ -1741,13 +1838,12 @@ func checkConfigMapping(applied []Configlet, newconfiglets []Configlet) (bool,
 	return actionReqd, configletAndBuilders, nil
 }
 
-
 func splitToConfigletAndBuilder(configlets []Configlet) (configletAndBuilderKeyNames, error) {
 	var (
-		configletNames []string
-		configletKeys []string
-		builderNames []string
-		builderKeys []string
+		configletNames     []string
+		configletKeys      []string
+		builderNames       []string
+		builderKeys        []string
 		reconcileConfiglet *Configlet
 	)
 
@@ -1789,12 +1885,11 @@ func splitToConfigletAndBuilder(configlets []Configlet) (configletAndBuilderKeyN
 	}, nil
 }
 
-
 // checkRemoveConfigMapping Creates map of configlets that needs to be there after removal of
 // specific configlets
 func checkRemoveConfigMapping(applied []Configlet, rmConfiglets []Configlet) (bool,
 	configletAndBuilderKeyNames, configletAndBuilderKeyNames, error,
-	) {
+) {
 	configletsToRemain := configletDifference(applied, rmConfiglets)
 
 	rmConfigletAndBuilders, err := splitToConfigletAndBuilder(rmConfiglets)

--- a/api/provisioning_test.go
+++ b/api/provisioning_test.go
@@ -255,3 +255,81 @@ func Test_checkRemoveConfigMapping(t *testing.T) {
 		})
 	}
 }
+
+func Test_changesNeeded(t *testing.T) {
+	type args struct {
+		applied    []Configlet
+		configlets []Configlet
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    *configletAndBuilderKeyNames
+		want1   *configletAndBuilderKeyNames
+		wantErr bool
+	}{
+		{
+			"",
+			args{
+				applied: []Configlet{
+					{
+						Reconciled: false,
+						Name:       "foo",
+						Key:        "foo",
+						Type:       "Static",
+					},
+					{
+						Reconciled: false,
+						Name:       "foo2",
+						Key:        "foo2",
+						Type:       "Static",
+					},
+					{
+						Reconciled: true,
+						Name:       "foo3",
+						Key:        "foo3",
+						Type:       "Reconciled",
+					},
+				},
+				configlets: []Configlet{
+					{
+						Reconciled: false,
+						Name:       "foo2",
+						Key:        "foo2",
+						Type:       "Static",
+					},
+				},
+			},
+			&configletAndBuilderKeyNames{
+				keys:   []string{"foo2"},
+				names:  []string{"foo2"},
+				bKeys:  nil,
+				bNames: nil,
+			},
+			&configletAndBuilderKeyNames{
+				keys:   []string{"foo", "foo3"},
+				names:  []string{"foo", "foo3"},
+				bKeys:  nil,
+				bNames: nil,
+			},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := changesNeeded(tt.args.applied, tt.args.configlets)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("changesNeeded() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("changesNeeded() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("changesNeeded() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Assuming https://github.com/aristanetworks/go-cvprac/issues/75 is correct, i.e., we can only add configlets to the end of already applied configlets list. Then, this change should give us a mechanism to rebuild, incl. its ordering, of  the complete list of configlets to be applied.

@cheynearista nudging in advance ;)