### PR TITLE
client/client: correct CVaaS url

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -315,6 +315,8 @@ func (c *CvpClient) initSession(host string) error {
 	c.url = fmt.Sprintf("%s://%s:%d", c.Protocol, host, c.GetPort())
 	if !c.IsCvaas {
 		c.url = c.url + "/web"
+	} else {
+		c.url = c.url + "/cvpservice"
 	}
 
 	c.Client = resty.New()


### PR DESCRIPTION
API endpoint path should be `/cvpservice` in case of CVaaS.

Ref: https://github.com/aristanetworks/cvprac/blob/develop/cvprac/cvp_client.py#L611-L613